### PR TITLE
fix: replace the way to instance the jpeg and png

### DIFF
--- a/Source/MailgunMessage.swift
+++ b/Source/MailgunMessage.swift
@@ -64,7 +64,7 @@ import Foundation
                 return "image/bmp"
             }
         }
-        
+
         var fileExtension: String {
             switch self {
             case .jpeg2000:
@@ -237,10 +237,9 @@ public class MailgunMessage {
 
         switch type {
         case .jpeg:
-            data = UIImageJPEGRepresentation(image, 0.9)!
+             data = image.jpegData(compressionQuality: 0.9)!
         case .png:
-            data = UIImagePNGRepresentation(image)!
-        }
+            data = image.pngData()!
 
         // Append extension if needed
         let filename = name.hasSuffix(".\(type.fileExtension)") ? name : name + ".\(type.fileExtension)"
@@ -264,7 +263,7 @@ public class MailgunMessage {
         let mimeType = type.mimeType
         let imgRep = image.representations.first! as! NSBitmapImageRep
         let data = imgRep.representation(using:type, properties:[:])!
-        
+
         // Append extension if needed
         let filename = name.hasSuffix(".\(type.fileExtension)") ? name : name + ".\(type.fileExtension)"
         if inline {


### PR DESCRIPTION
## Description
To solve the next error:
```
error: 'UIImageJPEGRepresentation' has been replaced by instance method 'UIImage.jpegData(compressionQuality:)'
error: 'UIImagePNGRepresentation' has been replaced by instance method 'UIImage.pngData()'
```

It was necessary to replace this
https://github.com/bre7/mailgun-swift/blob/860376bd1f0e67fa921e13a5c7067add16e24d9e/Source/MailgunMessage.swift#L239-L243
for
```
case .jpeg:
            data = image.jpegData(compressionQuality: 0.9)!
case .png:
            data = image.pngData()!
```